### PR TITLE
支持自定义 hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ $ ./start.sh
 
 应用即可启动运行：[localhost:3000](http://localhost:3000)
 
+注：如果你修改了 hostname，请将 localhost 替换为你自己的 hostname。
+
 ## 部署到 LeanEngine
 
 首先确认本机已经安装 [LeanCloud 命令行工具](https://leancloud.cn/docs/cloud_code_commandline.html)。

--- a/start.sh.example
+++ b/start.sh.example
@@ -1,6 +1,7 @@
 export LC_APP_ID=<your app id>
 export LC_APP_KEY=<your app key>
 export LC_APP_MASTER_KEY=<your master key>
+export LC_APP_HOST=`hostname`
 export LC_APP_PORT=3000
 
 python wsgi.py

--- a/wsgi.py
+++ b/wsgi.py
@@ -10,6 +10,7 @@ from cloud import engine
 
 APP_ID = os.environ['LC_APP_ID']
 MASTER_KEY = os.environ['LC_APP_MASTER_KEY']
+HOST = os.environ['LC_APP_HOST']
 PORT = int(os.environ['LC_APP_PORT'])
 
 
@@ -21,5 +22,6 @@ application = engine
 if __name__ == '__main__':
     # 只在本地开发环境执行的代码
     app.debug = True
-    server = simple_server.make_server('localhost', PORT, application)
+    server = simple_server.make_server(HOST, PORT, application)
+    print "Running on %s:%s ..." % (HOST, PORT)
     server.serve_forever()


### PR DESCRIPTION
如果用户修改了本机的 hostname，会导致 simple_server 报错：

```
[Errno 8] nodename nor servname provided, or not known
```

解决方法是增加了一个环境变量 LC_APP_HOST，值为本机的 hostname，并在启动服务时将 hard code 的 'localhost' 替换成真正的 `hostname`。
