### PR TITLE
feat: require leancloud python sdk >= 2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gevent>=1.0.2,<2.0.0
 gevent-websocket>=0.9.5,<1.0.0
-leancloud>=2.0.0,<3.0.0
+leancloud>=2.2.0,<3.0.0
 Werkzeug>=0.11.11,<1.0.0
 Flask>=1.0.0
 Flask-Sockets>=0.1,<1.0


### PR DESCRIPTION
python sdk 2.2.0 adds support for IM client online/offline hooks.