### PR TITLE
fix: downgrade werkzeug to 0.16.0

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Install lean-cli
         run: |
-          wget --quiet -O lean https://github.com/leancloud/lean-cli/releases/download/v0.23.0/lean-linux-x64
+          wget --quiet -O lean https://github.com/leancloud/lean-cli/releases/download/v0.24.4/lean-linux-x64
           sudo mv lean /usr/local/bin/lean
           chmod a+x /usr/local/bin/lean 
 
@@ -26,7 +26,7 @@ jobs:
         env:
           LC_USER: ${{ secrets.LEANCLICI }}
           PASSWORD: ${{ secrets.PASSWORD }}
-        run: lean login --username "$LC_USER" --password "$PASSWORD" --region US
+        run: lean login --username "$LC_USER" --password "$PASSWORD" --region us-w1
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+werkzeug==0.16.0
 gevent-websocket>=0.9.5,<1.0.0
 leancloud>=2.9.1,<3.0.0
 Flask>=1.0.0


### PR DESCRIPTION
werkzeug 1.0.0 brings in some incompatibilities.
Thus werkzeug is downgraded to 0.16.0 as a hot fix.

Thank 赤枫 for bringing this to our attention.
