### PR TITLE
fix ImportError: cannot import name 'soft_unicode' from 'markupsafe'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 gevent-websocket>=0.9.5,<1.0.0
 leancloud>=2.9.4,<3.0.0
+markupsafe<=2.0.1
 Flask>=1.0.0
 Flask-Sockets>=0.1,<1.0


### PR DESCRIPTION
https://github.com/pallets/jinja/issues/1585

修复从 `lean new` 创建的项目部署报错
```
[ERROR] Traceback (most recent call last):
[ERROR]   File "wsgi.py", line 10, in <module>
[ERROR]     from app import app
[ERROR]   File "/home/leanengine/app/app.py", line 6, in <module>
[ERROR]     from flask import Flask, jsonify, request
[ERROR]   File "/usr/share/pyenv/versions/3.8.13/lib/python3.8/site-packages/flask/__init__.py", line 14, in <module>
[ERROR]     from jinja2 import escape
[ERROR]   File "/usr/share/pyenv/versions/3.8.13/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
[ERROR]     from .environment import Environment
[ERROR]   File "/usr/share/pyenv/versions/3.8.13/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
[ERROR]     from .defaults import BLOCK_END_STRING
[ERROR]   File "/usr/share/pyenv/versions/3.8.13/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
[ERROR]     from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
[ERROR]   File "/usr/share/pyenv/versions/3.8.13/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
[ERROR]     from markupsafe import soft_unicode
[ERROR] ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/share/pyenv/versions/3.8.13/lib/python3.8/site-packages/markupsafe/__init__.py)
```